### PR TITLE
Disable timestamps

### DIFF
--- a/src/Console/Scrub.php
+++ b/src/Console/Scrub.php
@@ -75,6 +75,7 @@ class Scrub extends Command
         return tap(new class extends Model
         {
             public $exists = true;
+            public $timestamps = false;
             protected $guarded = [];
         }, function ($model) use ($table, $attributes) {
             $model->setTable($table);


### PR DESCRIPTION
This allows you to scrub tables without `created_at` and `updated_at` columns.