### PR TITLE
Add Laravel 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,9 @@ matrix:
     - php: "7.2"
       env: LARAVEL_VERSION="^6.0"
     - php: "7.3"
-      env: LARAVEL_VERSION="^6.0"
-    - php: "7.3"
       env: LARAVEL_VERSION="^7.0"
     - php: "7.4"
-      env: LARAVEL_VERSION="^7.0"
+      env: LARAVEL_VERSION="^8.0"
 
 ## Cache composer
 cache:
@@ -18,7 +16,7 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-  - composer require "illuminate/database:${LARAVEL_VERSION}" "illuminate/support:${LARAVEL_VERSION}" --no-update --no-interaction
+  - composer require "laravel/framework:${LARAVEL_VERSION}" --no-update --no-interaction
   - travis_retry composer update --no-interaction --prefer-dist
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,13 @@
     "description": "Data scrubber for Laravel applications",
     "type": "library",
     "require": {
-        "fzaninotto/faker": "^1.7",
-        "illuminate/database": "^6.0|^7.0",
-        "illuminate/support": "^6.0|^7.0"
+        "laravel/framework": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
+        "fakerphp/faker": "^1.9.1",
         "phpunit/phpunit" : "^8.5",
-        "orchestra/testbench" : "^4.0|^5.0",
-        "orchestra/database": "^4.0|^5.0"
+        "orchestra/testbench" : "^4.0|^5.0|^6.0",
+        "orchestra/database": "^4.0|^5.0|^6.0"
     },
     "autoload": {
         "psr-4" : {

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ return [
     ]
 ];
 ``` 
-**Carwash** uses the fabulous [Faker](https://github.com/fzaninotto/Faker) package under the hood to generate replacement data. Please refer to the Faker documentation for a complete list of [available formatters](https://github.com/fzaninotto/Faker#formatters).
+**Carwash** uses the fabulous [Faker](https://fakerphp.github.io/) package under the hood to generate replacement data. Please refer to the Faker documentation for a complete list of [available formatters](https://fakerphp.github.io/formatters/).
 
 More generally, the format of the **Carwash** config file is:
 ```php


### PR DESCRIPTION
I've added support for Laravel 8 and the new Faker fork. Faker is not a hard requirement in order to support both the fork as the original.